### PR TITLE
Prevent log to clutter stdout

### DIFF
--- a/server/config/default.json
+++ b/server/config/default.json
@@ -26,7 +26,7 @@
     }
   },
   "log": {
-    "type": "console",
+    "type": "stdout",
     "level": "info"
   },
   "slackWebhookUrl": null,

--- a/server/src/common/esClient/mongoosastic/index.js
+++ b/server/src/common/esClient/mongoosastic/index.js
@@ -138,7 +138,7 @@ function Mongoosastic(schema, options) {
     } catch (e) {
       let errorMsg = e.message;
       if (e.meta && e.meta.body) errorMsg = e.meta.body.error;
-      console.log("Error update mapping", errorMsg || e);
+      console.error("Error update mapping", errorMsg || e);
     }
   };
 
@@ -150,8 +150,8 @@ function Mongoosastic(schema, options) {
         _opts.id = this._id.toString();
         await esClient.index(_opts);
       } catch (e) {
-        console.log(e);
-        console.log(`Error index ${this._id.toString()}`, e.message || e);
+        console.error(e);
+        console.error(`Error index ${this._id.toString()}`, e.message || e);
         return reject();
       }
       resolve();
@@ -170,13 +170,13 @@ function Mongoosastic(schema, options) {
             await esClient.delete(_opts);
             return resolve();
           } catch (e) {
-            console.log(e);
+            console.error(e);
             await timeout(500);
             --tries;
           }
         }
       } catch (e) {
-        console.log(`Error delete ${this._id.toString()}`, e.message || e);
+        console.error(`Error delete ${this._id.toString()}`, e.message || e);
         return reject();
       }
       resolve();
@@ -191,7 +191,7 @@ function Mongoosastic(schema, options) {
         await u.index();
         count++;
         if (count % 100 == 0) {
-          console.log(`${count} indexed`);
+          console.error(`${count} indexed`);
         }
       });
   };

--- a/server/src/common/logger.js
+++ b/server/src/common/logger.js
@@ -18,9 +18,9 @@ const createStreams = () => {
     };
   };
 
-  const consoleStream = () => {
+  const consoleStream = (type) => {
     const pretty = new PrettyStream();
-    pretty.pipe(process.stdout);
+    pretty.pipe(process[type]);
     return {
       name: "console",
       level,
@@ -54,7 +54,7 @@ const createStreams = () => {
         },
       },
       (error) => {
-        console.log("Unable to send log to slack", error);
+        console.error("Unable to send log to slack", error);
       }
     );
 
@@ -65,7 +65,7 @@ const createStreams = () => {
     };
   };
 
-  const streams = [type === "console" ? consoleStream() : jsonStream(), mongoDBStream()];
+  const streams = [type === "json" ? jsonStream() : consoleStream(type), mongoDBStream()];
   if (config.slackWebhookUrl) {
     streams.push(slackStream());
   }

--- a/server/src/common/mongodb.js
+++ b/server/src/common/mongodb.js
@@ -4,7 +4,7 @@ const config = require("config");
 let mongooseInstance = mongoose;
 module.exports.connectToMongo = (mongoUri = config.mongodb.uri, mongooseInst = null) => {
   return new Promise((resolve, reject) => {
-    console.log(`MongoDB: Connection to ${mongoUri}`);
+    console.error(`MongoDB: Connection to ${mongoUri}`);
 
     const mI = mongooseInst || mongooseInstance;
     // Set up default mongoose connection
@@ -26,32 +26,32 @@ module.exports.connectToMongo = (mongoUri = config.mongodb.uri, mongooseInst = n
     });
 
     db.on("close", (e) => {
-      console.log("Error...close");
+      console.error("Error...close");
       reject(e);
     });
     db.on("error", (err) => {
-      console.log("Error...error", err);
+      console.error("Error...error", err);
       reject(err);
     });
     db.on("disconnect", (err) => {
-      console.log("Error...disconnect", err);
+      console.error("Error...disconnect", err);
       reject(err);
     });
     db.on("disconnected", (err) => {
-      console.log("Error...disconnected", err);
+      console.error("Error...disconnected", err);
       reject(err);
     });
     db.on("parseError", (err) => {
-      console.log("Error...parse", err);
+      console.error("Error...parse", err);
       reject(err);
     });
     db.on("timeout", (err) => {
-      console.log("Error...timeout", err);
+      console.error("Error...timeout", err);
       reject(err);
     });
 
     db.once("open", () => {
-      console.log("MongoDB: Connected");
+      console.error("MongoDB: Connected");
       resolve({ db });
     });
   });

--- a/server/src/common/utils/fileUtils.js
+++ b/server/src/common/utils/fileUtils.js
@@ -38,7 +38,7 @@ const writeXlsxFile = async (workbook, filePath, fileName) => {
     new Promise((resolve) => {
       XLSX.writeFileAsync(path.join(__dirname, `${filePath}/${fileName}`), workbook, (e) => {
         if (e) {
-          console.log(e);
+          console.error(e);
           throw new Error("La génération du fichier excel à échoué : ", e);
         }
         resolve();

--- a/server/src/jobs/convetionFilesImporter/importConventionFiles.js
+++ b/server/src/jobs/convetionFilesImporter/importConventionFiles.js
@@ -25,7 +25,7 @@ module.exports = async (db, publicOfsp, datadock, depp, dgefp) => {
         await db.collection("conventionfiles").insertMany(chunkpart);
         logger.info(`Inserted ${500 * (i + 1)}`);
       } catch (error) {
-        console.log(error);
+        console.error(error);
       }
     });
 

--- a/server/src/jobs/scriptWrapper.js
+++ b/server/src/jobs/scriptWrapper.js
@@ -5,8 +5,8 @@ const logger = require("../common/logger");
 const config = require("config");
 const { access, mkdir } = require("fs").promises;
 
-process.on("unhandledRejection", (e) => console.log(e));
-process.on("uncaughtException", (e) => console.log(e));
+process.on("unhandledRejection", (e) => console.error(e));
+process.on("uncaughtException", (e) => console.error(e));
 
 const createTimer = () => {
   let launchTime;
@@ -17,8 +17,8 @@ const createTimer = () => {
     stop: (results) => {
       const duration = moment.utc(new Date().getTime() - launchTime).format("HH:mm:ss.SSS");
       const data = results && results.toJSON ? results.toJSON() : results;
-      console.log(JSON.stringify(data || {}, null, 2));
-      console.log(`Completed in ${duration}`);
+      logger.info(JSON.stringify(data || {}, null, 2));
+      logger.info(`Completed in ${duration}`);
     },
   };
 };
@@ -47,7 +47,7 @@ const exit = async (rawError) => {
       .then(() => {})
       .catch((closeError) => {
         error = closeError;
-        console.log(error);
+        console.error(error);
       });
   }, 250);
 


### PR DESCRIPTION
Permet que les logs puissent être envoyés sur stderr (stream d'erreurs et de diagnostics) pour que la sortie la stdout soit dédiée à la CLI.
Cela permet par exemple de faire des `grep` sur les commandes des jobs
```sh
TABLES_CORRESPONDANCES_LOG_TYPE=stderr yarn --silent run ...
```