### PR TITLE
Stream /api/v1/entity/etablissements response

### DIFF
--- a/server/src/common/utils/mongooseUtils.js
+++ b/server/src/common/utils/mongooseUtils.js
@@ -1,0 +1,18 @@
+module.exports = {
+  paginate: async (Model, query, options = {}) => {
+    let total = await Model.count(query);
+    let page = options.page || 1;
+    let limit = options.limit || 10;
+    let skip = (page - 1) * limit;
+
+    return {
+      find: Model.find(query).skip(skip).limit(limit).lean(),
+      pagination: {
+        page,
+        resultats_par_page: limit,
+        nombre_de_page: Math.ceil(total / limit) || 1,
+        total,
+      },
+    };
+  },
+};

--- a/server/src/http/utils/httpUtils.js
+++ b/server/src/http/utils/httpUtils.js
@@ -1,0 +1,6 @@
+module.exports = {
+  sendJsonStream: (stream, res) => {
+    res.setHeader("Content-Type", "application/json");
+    stream.pipe(res);
+  },
+};

--- a/server/tests/integration/http/etablissement-test.js
+++ b/server/tests/integration/http/etablissement-test.js
@@ -1,0 +1,55 @@
+const { ok, strictEqual, deepStrictEqual } = require("assert");
+const httpTests = require("../../utils/httpTests");
+const { Etablissement } = require("../../../src/common/model");
+
+httpTests(__filename, ({ startServer }) => {
+  it("Vérifie qu'on peut lister des établissements", async () => {
+    const { httpClient } = await startServer();
+    await new Etablissement({
+      uai: "0010856A",
+    }).save();
+
+    const response = await httpClient.get("/api/v1/entity/etablissements");
+
+    strictEqual(response.status, 200);
+    let etablissements = response.data.etablissements;
+    ok(etablissements);
+    deepStrictEqual(etablissements[0].uai, "0010856A");
+  });
+
+  it("Vérifie qu'on peut lister des établissements avec de la pagination", async () => {
+    const { httpClient } = await startServer();
+    await new Etablissement({
+      uai: "0010856A",
+    }).save();
+    await new Etablissement({
+      uai: "0010856X",
+    }).save();
+
+    const response = await httpClient.get("/api/v1/entity/etablissements?page=1&limit=1");
+
+    strictEqual(response.status, 200);
+    let etablissements = response.data.etablissements;
+    ok(etablissements);
+    strictEqual(etablissements.length, 1);
+    deepStrictEqual(etablissements[0].uai, "0010856A");
+  });
+
+  it("Vérifie qu'on peut filtre les établissements avec une query", async () => {
+    const { httpClient } = await startServer();
+    await new Etablissement({
+      uai: "0010856A",
+    }).save();
+    await new Etablissement({
+      uai: "0010856X",
+    }).save();
+
+    const response = await httpClient.get(`/api/v1/entity/etablissements?query={"uai":"0010856A"}`);
+
+    strictEqual(response.status, 200);
+    let etablissements = response.data.etablissements;
+    ok(etablissements);
+    strictEqual(etablissements.length, 1);
+    deepStrictEqual(etablissements[0].uai, "0010856A");
+  });
+});


### PR DESCRIPTION
Permet d'éviter de mettre les documents en mémoire avant de les envoyer au client.
Les documents sont envoyés au fil de l'eau.
