### PR TITLE
Force info level for logs stored in db

### DIFF
--- a/server/src/common/logger.js
+++ b/server/src/common/logger.js
@@ -31,7 +31,7 @@ const createStreams = () => {
   const mongoDBStream = () => {
     return {
       name: "mongodb",
-      level,
+      level: "info",
       stream: BunyanMongodbStream({ model: Log }),
     };
   };


### PR DESCRIPTION
Permet d'éviter de stocker des logs avec le niveau `debug` et évite des incohérences dans le stockage liées au changement de level lors de l'exécution de commandes en ligne de commande