### PR TITLE
Ajout d'une route /etablissements.ndjson

### DIFF
--- a/server/tests/integration/http/etablissement-test.js
+++ b/server/tests/integration/http/etablissement-test.js
@@ -52,4 +52,24 @@ httpTests(__filename, ({ startServer }) => {
     strictEqual(etablissements.length, 1);
     deepStrictEqual(etablissements[0].uai, "0010856A");
   });
+
+  it("Vérifie qu'on peut lister des établissements en ndjson", async () => {
+    const { httpClient } = await startServer();
+    await insertEtablissement({
+      uai: "0010856A",
+    });
+    await insertEtablissement({
+      uai: "0751111A",
+    });
+    await insertEtablissement({
+      uai: "0751234J",
+    });
+
+    const response = await httpClient.get("/api/v1/entity/etablissements.ndjson?limit=2");
+
+    strictEqual(response.status, 200);
+    let etablissements = response.data.split("\n").filter((e) => e);
+    strictEqual(etablissements.length, 2);
+    deepStrictEqual(JSON.parse(etablissements[0]).uai, "0010856A");
+  });
 });


### PR DESCRIPTION
Permet d'envoyer les établissements au format [ndjson](http://ndjson.org/) et de les streamer.
