### PR TITLE
Use cursor when looping over etablissements in updater

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -82,7 +82,7 @@
     "mongoose-paginate": "5.0.3",
     "mongoose-schema-jsonschema": "1.4.7",
     "multipipe": "4.0.0",
-    "oleoduc": "0.5.10",
+    "oleoduc": "0.5.11",
     "passport": "0.4.1",
     "passport-http": "0.3.0",
     "passport-jwt": "4.0.0",

--- a/server/src/jobs/EtablissementsUpdater/updater/updater.js
+++ b/server/src/jobs/EtablissementsUpdater/updater/updater.js
@@ -1,7 +1,6 @@
 const logger = require("../../../common/logger");
 const { etablissementService } = require("../../../logic/services/etablissementService");
 // const { wait } = require("../../../common/utils/miscUtils");
-const { asyncForEach } = require("../../../common/utils/asyncUtils");
 const { Etablissement } = require("../../../common/model/index");
 
 const run = async (filter = {}, options = null) => {
@@ -18,11 +17,9 @@ const performUpdates = async (filter = {}, options = null) => {
     scope: { siret: true, geoloc: true, conventionnement: true, onisep: true },
   };
 
-  const etablissements = await Etablissement.find(filter);
-
-  logger.info(JSON.stringify(etablissementServiceOptions), etablissements.length);
   let count = 0;
-  await asyncForEach(etablissements, async (etablissement) => {
+  let cursor = Etablissement.find(filter).cursor();
+  for await (const etablissement of cursor) {
     try {
       const { updates, etablissement: updatedEtablissement, error } = await etablissementService(
         etablissement._doc,
@@ -46,7 +43,7 @@ const performUpdates = async (filter = {}, options = null) => {
     } catch (error) {
       logger.error(error);
     }
-  });
+  }
 
   // let offset = 0;
   // let limit = 1;

--- a/server/yarn.lock
+++ b/server/yarn.lock
@@ -6807,10 +6807,10 @@ object.values@^1.1.1:
     es-abstract "^1.18.0-next.1"
     has "^1.0.3"
 
-oleoduc@0.5.10:
-  version "0.5.10"
-  resolved "https://registry.yarnpkg.com/oleoduc/-/oleoduc-0.5.10.tgz#14863fd622a56775bbf436a2bd48b95e05434c12"
-  integrity sha512-HUQVf/8A+VN19M6lrr5XSejPeTYCluSzFqm7XpWIiIcfnu9ebnETp1fxasCBch6Mc1CjIg5cNZWAjD7JZPD9zw==
+oleoduc@0.5.11:
+  version "0.5.11"
+  resolved "https://registry.yarnpkg.com/oleoduc/-/oleoduc-0.5.11.tgz#7773e3f649585fe92f54f0547cbe1818b808bfed"
+  integrity sha512-LwBp1vyaGhviQ//AqIKkpppwDQ5UiVI6EDGhPqlIv3utPcwymH3yhTb9m+98s+aAhP1KY5vnx1bPrS8IbV8Szw==
   dependencies:
     cyclist "1.0.1"
     duplexer3 "0.1.4"


### PR DESCRIPTION
L'updater charge en mémoire tous les établissements de la base avant de réaliser les traitements ce qui prend environ 1Go de mémoire

![Capture d’écran du 2021-09-23 16-55-04](https://user-images.githubusercontent.com/221211/134531499-7fe3abf2-cf63-45ec-9214-e98e6941569d.png)


Cette PR propose d'itérer sur le curseur Mongodb et de récupérer chaque établissement juste avant de le traiter

![Capture d’écran du 2021-09-23 16-54-20](https://user-images.githubusercontent.com/221211/134531503-7b4110f6-ef39-49d4-8bc6-0157a0f12667.png)
